### PR TITLE
Upgrade for Ruby 3

### DIFF
--- a/lib/ae_skip_asset_pipeline.rb
+++ b/lib/ae_skip_asset_pipeline.rb
@@ -6,7 +6,7 @@ module AeSkipAssetPipeline
   mattr_accessor :enabled
 
   module AssetPipelineMethods
-    def javascript_pack_tag(*args)
+    def javascript_pack_tag(*args, **options)
       super unless AeSkipAssetPipeline.enabled
     end
 
@@ -18,7 +18,7 @@ module AeSkipAssetPipeline
       super unless AeSkipAssetPipeline.enabled
     end
 
-    def stylesheet_pack_tag(*args)
+    def stylesheet_pack_tag(*args, **options)
       super unless AeSkipAssetPipeline.enabled
     end
 

--- a/lib/ae_skip_asset_pipeline/version.rb
+++ b/lib/ae_skip_asset_pipeline/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AeSkipAssetPipeline
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
Ruby 3 doesn't convert keywords to hashes and hashes to keywords anymore so we have to match the underlying method signature exactly.