### PR TITLE
Add Backstage catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ae_skip_asset_pipeline
+  description: This gem provides functionality to skip the asset pipeline during
+    test. It's most useful for controller/functional tests.
+  tags:
+    - oss
+  annotations:
+    appfolio.com/package-location: url:https://rubygems.org/gems/ae_skip_asset_pipeline
+    appfolio.com/package-type: gem
+  name: ae-skip-asset-pipeline
+spec:
+  type: library
+  lifecycle: maintenance
+  owner: apm-test-automation


### PR DESCRIPTION
All Backstage component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance.

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-open-source-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-open-source-metadata)