### PR TITLE
chore: migrate npm registry from CodeArtifact to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@5.4.1
   gem-tool: appfolio/gem-tool@volatile
   node: circleci/node@7.2.0
+  public-packages: appfolio/public-packages@1
 
 workflows:
   rc:
@@ -19,21 +19,7 @@ workflows:
                 - '3.4.8'
                 - '3.3.10'
           after-checkout-steps:
-            - aws-cli/setup
-            - run:
-                name: Block default npm/yarn repositories
-                command: |
-                  curl -fsSL http://npm-yarn-blocklist.security.appf.io | while read -r hostname; do
-                    echo "127.0.0.1 $hostname" | sudo tee -a /etc/hosts
-                  done
-                  cat /etc/hosts
-            - run:
-                name: Generate CodeArtifact token
-                command: |
-                  export AWS_ACCESS_KEY_ID=$SHARED_CODEARTIFACT_AWS_KEY_ID
-                  export AWS_SECRET_ACCESS_KEY=$SHARED_CODEARTIFACT_AWS_SECRET_KEY
-                  export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain appfolio-ecr --domain-owner 195334327833 --region us-west-2 --query authorizationToken --output text`
-                  echo "export CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $BASH_ENV
+            - public-packages/setup
             - run:
                 name: Add dummy app bin path
                 command: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 always-auth=true
-registry=https://appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/
-//appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/:_authToken=${CODEARTIFACT_AUTH_TOKEN}
+registry=https://appfolio.jfrog.io/artifactory/api/npm/appfolio-ae_skip_asset_pipeline-npm/
+//appfolio.jfrog.io/artifactory/api/npm/appfolio-ae_skip_asset_pipeline-npm/:_authToken=${JFROG_ACCESS_TOKEN}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,8 +4,8 @@ nodeLinker: node-modules
 
 npmAlwaysAuth: true
 
-npmAuthToken: "${CODEARTIFACT_AUTH_TOKEN}"
+npmAuthToken: "${JFROG_ACCESS_TOKEN}"
 
-npmRegistryServer: "https://appfolio-ecr-195334327833.d.codeartifact.us-west-2.amazonaws.com/npm/appfolio-repo/"
+npmRegistryServer: "https://appfolio.jfrog.io/artifactory/api/npm/appfolio-ae_skip_asset_pipeline-npm/"
 
 yarnPath: .yarn/releases/yarn-4.10.2.cjs


### PR DESCRIPTION
## Summary

FEE-1627

Migrates this repo's npm registry configuration from AWS CodeArtifact to JFrog Artifactory as part of the org-wide rollout.

**Changes:**
- Registry config files (`.yarnrc.yml` / `.npmrc`): URL → JFrog, token → `JFROG_ACCESS_TOKEN`
- CircleCI: replaces CodeArtifact commands with `public-packages/setup` orb step
- GitHub Actions: replaces `appfolio/generate-codeartifact-token` with `appfolio/public-packages/setup@v1`
- Dockerfiles: secret mount IDs and env vars updated
- Docs: updates CodeArtifact references to JFrog

**No action needed on your end** — just review and merge. If CI is red or you have questions, ping #jfrog-support.

## Local setup

Run `otto login --install-jfrog-token` to get a local `JFROG_ACCESS_TOKEN` (lasts 1 year).
