### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   gem-tool: appfolio/gem-tool@volatile
   node: circleci/node@7.2.0
-  public-packages: appfolio/public-packages@1
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:

--- a/Appraisals
+++ b/Appraisals
@@ -2,19 +2,19 @@
 
 if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   appraise "ruby-#{RUBY_VERSION}_activesupport72" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_skip_asset_pipeline-gem/' do
       gem 'activesupport', '~> 7.2.0'
     end
   end
 
   appraise "ruby-#{RUBY_VERSION}_activesupport80" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_skip_asset_pipeline-gem/' do
       gem 'activesupport', '~> 8.0.0'
     end
   end
 
   appraise "ruby-#{RUBY_VERSION}_activesupport81" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_skip_asset_pipeline-gem/' do
       gem 'activesupport', '~> 8.1.0'
     end
   end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_skip_asset_pipeline-gem/'
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_skip_asset_pipeline-gem/' do
   gem 'actionpack', '>= 7.2', '< 8.2'
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Updated `allowed_push_host` in gemspec to JFrog URL
- Updated `package-location` annotation in catalog-info.yaml to JFrog URL
- Added `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration