### PR TITLE
Bump tar/immutable in dummy app to fix Dependabot critical/high CVEs

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -38,7 +38,7 @@
     "micromatch": "^4.0.8",
     "flatted": "3.4.2",
     "glob": "10.5.0",
-    "immutable": "4.3.8",
+    "immutable": "4.3.9",
     "js-yaml": "3.14.2",
     "json5": "2.2.2",
     "loader-utils": "2.0.4",
@@ -57,7 +57,7 @@
     "serialize-javascript": "7.0.5",
     "sha.js": "2.4.12",
     "postcss-svgo/svgo": "2.8.3",
-    "tar": "7.5.13",
+    "tar": "7.5.19",
     "terser": "5.14.2",
     "yaml": "1.10.3"
   }

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -4844,10 +4844,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:4.3.8":
-  version: 4.3.8
-  resolution: "immutable@npm:4.3.8"
-  checksum: 10c0/3de58996305a0faf6ef3fc0685f996c42653ad757760214f5aec7d4a6b59ea7abb882522c5f9a61776fae88c0b45e08eb77cbded5a4f57745ec7c63f9642e44b
+"immutable@npm:4.3.9":
+  version: 4.3.9
+  resolution: "immutable@npm:4.3.9"
+  checksum: 10c0/394faa90ac8f2f62824e6c639705efdb8313787d6bc7864e28a48ee36aa2ba4b724eaf54a701ad991c278967a412b09143dd24fd19e3e2b0204eb481a5afa6ef
   languageName: node
   linkType: hard
 
@@ -8575,16 +8575,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.13":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+"tar@npm:7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19::__archiveUrl=https%3A%2F%2Fappfolio.jfrog.io%2Fartifactory%2Fapi%2Fnpm%2Fappfolio-ottoweb_app-npm%2Ftar%2F-%2Ftar-7.5.19.tgz"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `tar` 7.5.13 → 7.5.19 and `immutable` 4.3.8 → 4.3.9 in `spec/dummy` (via `resolutions`)
- Closes Dependabot alerts:
  - #150 (critical) CVE-2026-59873 — node-tar decompression/parse DoS
  - #147 (high) CVE-2026-59874 — node-tar negative entry size infinite loop
  - #145 (high) CVE-2026-59879 — Immutable.js `List` trie overflow DoS
  - #146 (high) CVE-2026-59880 — Immutable.js hash-collision DoS
- Both are same-major patch releases with no API changes, required elsewhere as `^7.4.3`/`^6.0.2` (tar) and `^4.0.0` (immutable) — bumps stay within compatible ranges.
- Isolated from the `svgo` fix (DUX-9429 / separate PR) since that one needs extra build verification.

Jira: DUX-9428

## Test plan
- [x] `yarn install` in `spec/dummy` — resolved cleanly, no new peer warnings
- [x] `bin/webpack` production build in `spec/dummy` — succeeded, assets emitted normally
- [x] `bundle exec rspec` — 14 examples, 0 failures