### PR TITLE
DUX-11077: Bump brace-expansion to 5.0.9 to fix DoS vulnerability

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -26,7 +26,7 @@
     "ansi-regex": "4.1.1",
     "autoprefixer": ">=10.4.0",
     "bn.js": "4.12.3",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "braces": "3.0.3",
     "browserify-sign": "4.2.2",
     "cipher-base": "1.0.7",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -2697,12 +2697,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8::__archiveUrl=https%3A%2F%2Fappfolio.jfrog.io%2Fartifactory%2Fapi%2Fnpm%2Fappfolio-kermit-npm%2Fbrace-expansion%2F-%2Fbrace-expansion-5.0.8.tgz"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `brace-expansion` from 5.0.8 to 5.0.9 in the dummy app to address a high-severity denial of service (DoS) vulnerability.

## Vulnerability Details

**CVE:** CVE-2026-69152  
**GHSA:** GHSA-rgw5-rvv9-x895  
**CVSS Score:** 7.5 (High)  
**Affected versions:** >= 4.0.0, < 5.0.9

The `maxLength` mitigation in 5.0.8 (addressing CVE-2026-14257) was incomplete. It bounds the accumulator where results are combined, but not the intermediate arrays that feed it. This allows a ~25 KB input to crash the Node process.

## Changes

- Updated `spec/dummy/package.json`: `brace-expansion@5.0.8` → `brace-expansion@5.0.9`
- Updated `spec/dummy/yarn.lock` with resolved dependency info

## Testing

The dummy app dependency has been reinstalled cleanly with the new version. Since `brace-expansion` is a transitive dev tooling dependency (webpack/glob matching) with no direct test surface, no additional test changes are required.

## Additional Context

Dependabot alert: https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/158

---
**Agent session:** https://supernova.dx.appf.io/coders/9afae00b-17ff-44b2-8db9-6ff0aee4cb69