### PR TITLE
DUX-11076: Bump ip-address to 10.3.1 to resolve CVE-2026-69192

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -34,7 +34,7 @@
     "cross-spawn@^7.0.3": "7.0.6",
     "decode-uri-component": "0.2.1",
     "elliptic": "6.6.1",
-    "ip-address": ">=10.1.1",
+    "ip-address": "10.3.1",
     "micromatch": "^4.0.8",
     "flatted": "3.4.2",
     "glob": "10.5.0",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -4982,10 +4982,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:>=10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0::__archiveUrl=https%3A%2F%2Fappfolio.jfrog.io%2Fartifactory%2Fapi%2Fnpm%2Fappfolio-kermit-npm%2Fip-address%2F-%2Fip-address-10.2.0.tgz"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+"ip-address@npm:10.3.1":
+  version: 10.3.1
+  resolution: "ip-address@npm:10.3.1"
+  checksum: 10c0/45b1c31e2cc53d6354ea39f276d70c365a9b0332e7ca2140a9ad4cdb7fdb9d73b6a7ec0d8bf19993d8dce7ab636cd86c46c3e417b98db5ccb8c25546fe8c0b17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Resolves Dependabot security alert #159 by bumping the `ip-address` dependency from 10.2.0 to 10.3.1.

## Changes
- Updated `ip-address` version constraint in `spec/dummy/package.json` from `>=10.1.1` to `10.3.1` (pinned to exact version)
- Updated `spec/dummy/yarn.lock` to reflect the new resolved version

## Security Fix
**CVE-2026-69192** / **GHSA-mwp4-54f8-5fhr** (Severity: HIGH)

The `Address4` class in `ip-address` <=10.3.0 decodes octets with leading zeros as decimal, while standard resolvers (WHATWG URL parser, `inet_aton`, `getaddrinfo`) decode them as octal. This discrepancy allows SSRF and trust-boundary bypass attacks.

The patch in 10.3.1 aligns the behavior with standard resolvers.

## Notes
- `ip-address` is a transitive dependency (via `socks` → `socks-proxy-agent`)
- Pinned to exact version 10.3.1 rather than a range to ensure the minimum patched version is used
- No direct code changes; only dependency version updates

## Additional Context

Dependabot alert: https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/159

---
**Agent session:** https://supernova.dx.appf.io/coders/0ad8ebc2-242d-4d75-a83c-13a68f03de8a