### PR TITLE
DUX-12137: Bump js-yaml to 3.15.1 and nanoid to 3.3.18 to resolve high-severity DoS vulnerabilities

### DIFF
--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -47,6 +47,7 @@
     "color-string": "1.5.5",
     "minimatch": "10.2.6",
     "minimist": "1.2.8",
+    "nanoid": "3.3.18",
     "nth-check": "2.0.1",
     "pbkdf2": "3.1.5",
     "picomatch": "2.3.2",

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -47,7 +47,6 @@
     "color-string": "1.5.5",
     "minimatch": "10.2.6",
     "minimist": "1.2.8",
-    "nanoid": "3.3.18",
     "nth-check": "2.0.1",
     "pbkdf2": "3.1.5",
     "picomatch": "2.3.2",

--- a/spec/dummy/package.json
+++ b/spec/dummy/package.json
@@ -39,7 +39,7 @@
     "flatted": "3.4.2",
     "glob": "10.5.0",
     "immutable": "4.3.9",
-    "js-yaml": "3.15.0",
+    "js-yaml": "3.15.1",
     "json5": "2.2.2",
     "loader-utils": "2.0.4",
     "lodash": "4.18.1",

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -5771,7 +5771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.18":
+"nanoid@npm:^3.3.16":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -5771,12 +5771,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -5237,15 +5237,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.15.0":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0::__archiveUrl=https%3A%2F%2Fappfolio.jfrog.io%2Fartifactory%2Fapi%2Fnpm%2Fappfolio-kermit-npm%2Fjs-yaml%2F-%2Fjs-yaml-3.15.0.tgz"
+"js-yaml@npm:3.15.1":
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Resolves both open High-severity Dependabot alerts on this repo:
- GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) — bumps js-yaml from 3.15.0 to 3.15.1
- nanoid infinite-loop DoS — bumps nanoid to 3.3.18 (transitive via postcss)

## Details

### js-yaml (alert [#160](https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/160))
- **Vulnerability:** Quadratic CPU consumption in `!!omap` resolution
- **Severity:** HIGH (CVSS 7.5)
- **Affected versions:** >= 3.0.0, < 3.15.1
- **Fix:** js-yaml 3.15.1 includes the necessary security patch

### nanoid (alert [#162](https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/162))
- **Vulnerability:** Custom generators can loop indefinitely when size is zero
- **Severity:** HIGH
- **Fix:** nanoid 3.3.18; pulled in transitively via postcss. The existing `^3.3.16` range already allows 3.3.18, so this is a lockfile-only refresh — no package.json change needed.

## Changes
- Updated `js-yaml` resolutions override in `spec/dummy/package.json` from 3.15.0 to 3.15.1
- Refreshed the `nanoid` resolution in `spec/dummy/yarn.lock` to 3.3.18 (within the existing `^3.3.16` range)

## Testing
- Verified webpack config building works correctly with the new versions
- Confirmed js-yaml 3.15.1 correctly parses the app's `config/webpacker.yml`
- Confirmed `yarn why nanoid` resolves to 3.3.18 via postcss
- No regressions detected from version bumps

## Additional Context

Dependabot alerts:
- https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/160
- https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/162

---
**Agent session:** https://supernova.dx.appf.io/coders/90cc7783-3f04-4d1a-b627-4a314a0dc103
