### PR TITLE
DUX-12339: Bump nanoid to 3.3.17 to resolve CVE-2026-67213

### DIFF
--- a/spec/dummy/yarn.lock
+++ b/spec/dummy/yarn.lock
@@ -5772,11 +5772,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.17
+  resolution: "nanoid@npm:3.3.17"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Dependabot flagged a HIGH severity security alert (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, CVSS 5.9) for `nanoid` < 3.3.17 in `spec/dummy/yarn.lock`. The vulnerability allows a denial-of-service: `nanoid`'s `customAlphabet`/`customRandom` functions loop infinitely if called with `size: 0`, hanging the calling thread.

`nanoid` is a transitive dependency here, pulled in via `postcss` as part of the dummy Rails app's CSS/webpack build chain — it's not a direct dependency of this repo. This PR bumps it to 3.3.17, the earliest patched version, per the standing dependency-update policy (explicitly not the latest available, 3.3.18).

## Changes

- `spec/dummy/yarn.lock` — bumped the `nanoid@npm:^3.3.16` entry's resolved `version` and `resolution` from `3.3.16` to `3.3.17`, and updated the `checksum` accordingly. This is the only file changed.
- `spec/dummy/package.json` was **deliberately left untouched** — no `resolutions` override was added. Earlier iterations of this fix did add a manifest-level override to force the exact pin, but that approach was reverted in favor of directly hand-editing the `yarn.lock` entry's version/checksum, mirroring how the same alert was fixed in the sibling repo PR `appfolio/kermit#1559`. Reviewers should not expect to see a `package.json` diff — its absence is intentional.
- The intermediate commits from those earlier iterations were squashed into a single commit (`8f0ad30`).

## Testing

- Ran `yarn install --immutable` against the hand-edited lockfile — succeeded with no drift, confirming the `postcss`-permitted range `^3.3.16` naturally resolves to 3.3.17 without a manifest pin.
- Verified `node_modules/nanoid/package.json` reports version `3.3.17`.
- Ran smoke tests exercising `postcss` and `nanoid` directly (the actual consumers in the CSS/webpack build chain) to confirm they still work correctly with the patched version.
- Ran a scoped/sanity pass of the Ruby spec suite as an additional check (not the full suite, per task guidance) — no failures reported.

## Additional Context

Dependabot alert: https://github.com/appfolio/ae_skip_asset_pipeline/security/dependabot/161

---
**Agent session:** https://supernova.dx.appf.io/coders/baa80373-328f-4cb1-b8e4-7448ed330ec0